### PR TITLE
Updating tasks to support Mythic 3.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,27 @@
   include_role:
     name: geerlingguy.docker
 
-- name: Install Pip
+- name: Install Pip role and vars for pip
   include_role:
     name: geerlingguy.pip
+  vars:
+    pip_install_packages:
+      - docker
+      - botocore
+      - boto3
+      - requests
+    pip_executable: pip3
+    pip_package: python3-pip
+ 
 
 - name: Install pydocker
   pip:
     name: docker
+
+- name: Install golang
+  include_role:
+    name: gantsign.golang
+
 
 - name: Download Mythic
   ansible.builtin.git:
@@ -21,13 +35,34 @@
     dest: "{{ installation_path }}"
     version: "{{ mythic_version }}"
 
+- name: Make Go binaries
+  command: sudo make
+  args:
+    chdir: "{{ installation_path }}"
+
+  
+- name: Check and move file if present
+  stat:
+    path: "{{ installation_path }}/mythic-cli"
+  register: mythic_cli_stat
+
+- name: Move file to /bin/ if it exists
+  command: cp "{{ installation_path }}/mythic-cli" /bin/
+  when: mythic_cli_stat.stat.exists
+
+- name: Continue with other tasks 
+  debug:
+    msg: "File has been moved to /bin/, continuing with other tasks"
+  when: mythic_cli_stat.stat.exists
+
+
 - name: Check for mythic config
   stat:
     path: "{{ installation_path }}/.env"
   register: env_stat
 
 - name: Create mythic config
-  shell: ./mythic-cli config > .env
+  shell: ./mythic-cli config 
   args:
     chdir: "{{ installation_path }}"
   when: not env_stat.stat.exists
@@ -49,14 +84,15 @@
     name: mythic_server
   register: mythic_result
 
-- name: Start Mythic
-  command: ./mythic-cli mythic start
-  args:
-    chdir: "{{ installation_path }}"
-  when: not mythic_result.exists
 
 - name: Install Agents
   include_tasks: install_agents.yml
   vars:
     agent: "{{ item }}"
   loop: "{{ agents }}"
+
+
+- name: Start mythic 
+  command: "./mythic-cli start"
+  args:
+    chdir: "{{ installation_path }}"


### PR DESCRIPTION
### Purporse
Warhorse utilizes this repository to automatically deploy Mythic and was served as an example in the HackerOps course created by Ralph May:

https://www.antisyphontraining.com/on-demand-courses/hackerops-w-ralph-may/

Warhorse is essentially a wrapper for Terraform/Ansible to deploy common offensive infrastructure in a "opsec" safe way. The project can be found here:

https://github.com/warhorse

With the latest release of Mythic 3.0, the project no longer provides a pre-compiled binary. This pull request ensures the Mythic repo is pulled and mythic-cli is made to start all services automatically using Ansible. The ".env" file had to also be modified on how it was created due to a slight change. However, installation of agents/services is still consistent and can be utilized with this ansible-role. As an example, I simply installed the HTTP C2 server and Apollo agent using this role.  My goal here was to support the HackerOps course and anyone interested in learning Terraform/Ansible. 

### Test Cases
Used Warhorse alongside this role to deploy Mythic with the HTTP C2 Server and Apollo agent. All services were up and properly working after deployment. 

```
Services:
     apollo                    Up 6 minutes
     http                      Up 6 minutes
     mythic_documentation      Up 6 minutes (healthy)
     mythic_graphql            Up 5 minutes (healthy)
     mythic_jupyter            Up 6 minutes (healthy)
     mythic_nginx              Up 6 minutes (healthy)
     mythic_postgres           Up 6 minutes (healthy)
     mythic_rabbitmq           Up 6 minutes (healthy)
     mythic_react              Up 6 minutes (healthy)
     mythic_server             Up 6 minutes (healthy)
     neo4j                     Up 5 minutes
```

### Changes

- Modified Pip installation slightly due to recent updates to Docker and the "requests" library from Pip. This was primarily done during testing for troubleshooting purposes with the latest version of Ansible
- Included Golang in the installation to ensure mythic-cli compiles this was done using the following role "gantsign.golang"
- Created checks to compile mythic-cli, verify the file is present, and copy it to /bin/ mainly to ensure no additional errors. The rest of the ansible role uses mythic-cli in the proper directory
- Modified how the configuration file is created by the role to support Mythic 3.0
- Starts mythic after agents/services are all fully installed

### Future Consideration
There may be a downside to how I compiled the binary since if the roles fails after it was created, you may need to delete the "mythic" folder and retry. May want to investigate a better implementation to check if "mythic-cli" already exists before trying to compile. 


