### PR TITLE
Update defaults to fix known upstream gantsign.golang bug

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for ansible-role-mythic
+# https://github.com/gantsign/ansible-role-golang/issues/413
+golang_mirror: https://go.dev/dl


### PR DESCRIPTION
This PR patches an upstream issue (https://github.com/gantsign/ansible-role-golang/issues/413) when downloading golang from their original CDN. Initially I received this error:
```
TASK [gantsign.golang : Download Go language SDK] ******************************
[ERROR]: Task failed: Module failed: Request failed
Origin: /home/vagrant/.ansible/roles/gantsign.golang/tasks/main.yml:28:3

26     dest: '{{ golang_download_dir }}'
27
28 - name: Download Go language SDK
     ^ column 3

fatal: [teamserver]: FAILED! => {"changed": false, "dest": "/root/.ansible/tmp/downloads/go1.24.2.linux-amd64.tar.gz", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 403: Forbidden", "status_code": 403, "url": "https://storage.googleapis.com/golang/go1.24.2.linux-amd64.tar.gz"}
```