### PR TITLE
fixing boolean error on more recent versions of ansible

### DIFF
--- a/tasks/install_agents.yml
+++ b/tasks/install_agents.yml
@@ -2,7 +2,7 @@
   assert:
     that:
       - agent is defined
-      - installation_path
+      - installation_path is defined
 
 - name: Install Agent
   command: "./mythic-cli install github {{ agent.repo }} {{ agent.branch }} -f"


### PR DESCRIPTION
I'm guessing this functionality was deprecated at some point & now it needs to be a boolean response, so this PR does that.

Here's the error I received when running from the latest version of the ansible pypi version:
```
TASK [t94j0.mythic : Assert mandatory variables] *******************************
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'str' at '/home/vagrant/.ansible/roles/t94j0.mythic/defaults/main.yml:4:20'. Conditionals must have a boolean result.

Task failed.
Origin: /home/vagrant/.ansible/roles/t94j0.mythic/tasks/install_agents.yml:1:3

1 - name: Assert mandatory variables
    ^ column 3

<<< caused by >>>

Conditional result (True) was derived from value of type 'str' at '/home/vagrant/.ansible/roles/t94j0.mythic/defaults/main.yml:4:20'. Conditionals must have a boolean result.
Origin: /home/vagrant/.ansible/roles/t94j0.mythic/tasks/install_agents.yml:5:9

3     that:
4       - agent is defined
5       - installation_path
          ^ column 9

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [teamserver]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True) was derived from value of type 'str' at '/home/vagrant/.ansible/roles/t94j0.mythic/defaults/main.yml:4:20'. Conditionals must have a boolean result."}
```